### PR TITLE
Fix array lengths, use QMK ARRAY_SIZE macro

### DIFF
--- a/kb16/lib/layer_status/layer_status.c
+++ b/kb16/lib/layer_status/layer_status.c
@@ -17,8 +17,9 @@
  */
 
 #include "quantum.h"
+#include "../util.h"
 
-#define ANIM_SIZE 525  // number of bytes in array, minimize for adequate firmware size, max is 1024
+#define ANIM_SIZE 512  // number of bytes in array, minimize for adequate firmware size, max is 1024
 
 void render_layer_status(void) {
     static const char PROGMEM layer_status[][ANIM_SIZE] = {
@@ -421,5 +422,6 @@ void render_layer_status(void) {
 }
 
     };
-    oled_write_raw_P(layer_status[get_highest_layer(layer_state)], sizeof(layer_status[0]));
+
+	WRITE_RAW(layer_status[get_highest_layer(layer_state)]);
 }

--- a/kb16/lib/logo.c
+++ b/kb16/lib/logo.c
@@ -16,8 +16,9 @@
  */
 
 #include "quantum.h"
+#include "./util.h"
 
-#define ANIM_SIZE 525  // number of bytes in array, minimize for adequate firmware size, max is 1024
+#define ANIM_SIZE 512  // number of bytes in array, minimize for adequate firmware size, max is 1024
 
 void render_logo(void) {
     static const char PROGMEM doio[][ANIM_SIZE] = {
@@ -57,5 +58,5 @@ void render_logo(void) {
         }
     };
 
-    oled_write_raw_P(doio[0], ANIM_SIZE);
+    WRITE_RAW(doio[0]);
 }

--- a/kb16/lib/util.h
+++ b/kb16/lib/util.h
@@ -1,0 +1,39 @@
+/* This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// These functions were added to `quantum/util.h` in late 2022,
+// have not been ported to Vial yet
+
+#if !defined(IS_ARRAY)
+/**
+ * @brief Returns true if the value is an array, false if it's a pointer.
+ *
+ * This macro is ill-formed for scalars, which is OK for its intended use in
+ * ARRAY_SIZE.
+ */
+#    define IS_ARRAY(value) (!__builtin_types_compatible_p(typeof((value)), typeof(&(value)[0])))
+#endif
+
+#if !defined(ARRAY_SIZE)
+/**
+ * @brief Computes the number of elements of the given array at compile time.
+ *
+ * This Macro can only be used for statically allocated arrays that have not
+ * been decayed into a pointer. This is detected at compile time, though the
+ * error message for scalar values is poor.
+ */
+#    define ARRAY_SIZE(array) (__builtin_choose_expr(IS_ARRAY((array)), sizeof((array)) / sizeof((array)[0]), (void)0))
+#endif
+
+#define WRITE_RAW(x) oled_write_raw_P(x, ARRAY_SIZE(x))


### PR DESCRIPTION
This PR fixes the way `oled_write_raw_P` is called, currently the array sizes for logo and layer are set to 525 instead of 512, causing erroneous data to get written to the OLED buffer as far as I can tell.  Uses [ARRAY_SIZE](https://github.com/qmk/qmk_firmware/blob/master/quantum/util.h#L47), which was added to QMK in August and hasn't been ported to Vial QMK, so definitions are included as part of this PR in `util.h`.  Tested on my rev2 KB16, appears to give back 200 bytes or so in firmware size.

Thanks for this keymap, I hope this is helpful!